### PR TITLE
Should work this time

### DIFF
--- a/exe/relative-usage-new.php
+++ b/exe/relative-usage-new.php
@@ -2,11 +2,11 @@
 <?php
 /**
  * This shell is used to delegate the relative usage calculation to the external
- * Gauge class
+ * Meter class
  */
 
 require __DIR__ . '/../../includes/db.php';
-require __DIR__ . '/../../includes/class.Gauge.php';
+require __DIR__ . '/../../includes/class.Meter.php';
 
 // ..$id, $daySets, $start, $end
 $id = $argv[1];
@@ -14,17 +14,7 @@ $daySets = $argv[2];
 $start = $argv[3];
 $end = $argv[4];
 
-$gauge = new Gauge($db);
+$meter = new Meter($db);
+echo $meter->relativeValueOfMeterFromTo($id, $daySets, $start, $end);
 
-$stmt = $db->prepare('SELECT id, current, units FROM meters WHERE id = ?');
-$stmt->execute([$id]);
-
-$meter = $stmt->fetch();
-
-$data = $gauge->filterArray(
-    $gauge->getData($id, $start, $end),
-    $daySets
-);
-
-echo $gauge->relativeValueNow($id, $daySets, $start, $end);
 ?>


### PR DESCRIPTION
I deleted the gauge class and expanded the meter class. Specifically, the meter class now has `relativeValueOfMeterFromTo` and `relativeValueOfMeterWithPoints` methods that calculate the relative value of a meter given a start/end date, or given the number of points to retrieve from the db. The latter method requires that you specify a resolution for the data as it can not be chosen automatically based on the start date. See my gauges repo for examples of both these methods in use.